### PR TITLE
fix: remove duplicated status code

### DIFF
--- a/atom/browser/net/url_request_buffer_job.cc
+++ b/atom/browser/net/url_request_buffer_job.cc
@@ -120,7 +120,7 @@ void URLRequestBufferJob::Kill() {
 }
 
 void URLRequestBufferJob::GetResponseInfo(net::HttpResponseInfo* info) {
-  std::string status("HTTP/1.1 200 OK");
+  std::string status("HTTP/1.1 ");
   status.append(base::IntToString(status_code_));
   status.append(" ");
   status.append(net::GetHttpReasonPhrase(status_code_));


### PR DESCRIPTION
#### Description of Change
Removed the hardcoded status code string from the buffer protocol response. The actual status code is immediately appended, so previously the response would contain 2 status codes (e.g. `HTTP/1.1 200 OK200 OK`)
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes
<!-- Used to describe release notes for future release versions. Use `no-notes` to indicate no user-facing changes. -->

Notes: no-notes